### PR TITLE
Enforce Hessenberg structure

### DIFF
--- a/src/implicit_restart.jl
+++ b/src/implicit_restart.jl
@@ -73,7 +73,7 @@ end
 # """
 # Assume a Hessenberg matrix of size (n + 1) × n.
 # """
-function single_shift!(H_whole::AbstractMatrix, min, max, μ, Q::AbstractMatrix; debug = false)
+function single_shift!(H_whole::AbstractMatrix{Tv}, min, max, μ::Tv, Q::AbstractMatrix; debug = false) where {Tv}
     # println("Single:")
     H = view(H_whole, min : max + 1, min : max)
     # @assert size(H, 1) == size(H, 2) + 1

--- a/test/shift_double.jl
+++ b/test/shift_double.jl
@@ -21,11 +21,18 @@ end
 @testset "Double Shifted QR" begin
     n = 20
 
+    is_hessenberg(H) = vecnorm(tril(H, -2)) == 0
+
     # Test on a couple random matrices
     for i = 1 : 50
         H, λs, μ = generate_real_H_with_imaginary_eigs(n, Float64)
         Q = eye(n)
-        H′ = double_shift!(H, 1, n, μ, Q)
-        @test λs ≈ sort!(eigvals(view(H′, 1:n-2, 1:n-2)), by = abs)
+        double_shift!(H, 1, n, μ, Q)
+
+        # Test whether exact shifts retain the remaining eigenvalues after the QR step
+        @test λs ≈ sort!(eigvals(view(H, 1:n-2, 1:n-2)), by = abs)
+
+        # Test whether the full matrix remains Hessenberg.
+        @test is_hessenberg(H)
     end
 end


### PR DESCRIPTION
Simply enforce the Hessenberg structure by zeroing out the subdiagonal element after applying a Given's rotation. Add a test that the Hessenberg structure is preserved, with single and double shifts in real and complex arithmetic.