### PR TITLE
Reinitialize when invariant subspace is found

### DIFF
--- a/src/IRAM.jl
+++ b/src/IRAM.jl
@@ -7,6 +7,13 @@ export partial_schur, LM, SR, LR, SI, LI, eigvalues, schur_to_eigen
 struct Arnoldi{T,TV<:StridedMatrix{T},TH<:StridedMatrix{T}}
     V::TV
     H::TH
+
+    function Arnoldi{T}(matrix_order::Int, krylov_dimension::Int) where {T}
+        krylov_dimension <= matrix_order || throw(ArgumentError("Krylov dimension should be less than matrix order."))
+        V = Matrix{T}(undef, matrix_order, krylov_dimension + 1)
+        H = zeros(T, krylov_dimension + 1, krylov_dimension)    
+        return new{T,typeof(V),typeof(H)}(V, H)
+    end
 end
 
 struct PartialSchur{TQ,TR}

--- a/src/expansion.jl
+++ b/src/expansion.jl
@@ -1,43 +1,129 @@
 using Random
 using LinearAlgebra
+using LinearAlgebra.BLAS: gemv!
 
 """
-Allocate some space for an Arnoldi factorization of A where the Krylov subspace has
-dimension `max` at most.
+    reinitialize!(a::Arnoldi, j::Int = 0) -> a
+
+Generate a random `j+1`th column orthonormal against V[:,1:j]
+
+Returns true if the column is a valid new basis vector.
+Returns false if the column is numerically in the span of the previous vectors.
 """
-function initialize(::Type{T}, n::Int, max::Int = 30) where {T}
-    V = Matrix{T}(undef, n, max + 1)
-    H = zeros(T, max + 1, max)
+function reinitialize!(arnoldi::Arnoldi{T}, j::Int = 0) where {T}
+    V = arnoldi.V
+    v = view(V, :, j+1)
 
-    v1 = view(V, :, 1)
-    rand!(v1)
-    v1 ./= norm(v1)
+    # Generate a new random column
+    rand!(v)
 
-    Arnoldi{T,typeof(V),typeof(H)}(V, H)
+    # Norm before orthogonalization
+    rnorm = norm(v)
+
+    # Just normalize, don't Orthogonalize
+    if j == 0
+        v ./= rnorm
+        return true
+    end
+
+    # Constant used by ARPACK.
+    η = √2 / 2
+    Vprev = view(V, :, 1:j)
+
+    # Orthogonalize: h = Vprev' * v, v ← v - Vprev * Vprev' * v = v - Vprev * h
+    h = Vprev' * v
+    gemv!('N', -one(T), Vprev, h, one(T), v)
+
+    # Norm after orthogonalization
+    wnorm = norm(v)
+
+    # Reorthogonalize once
+    if wnorm < η * rnorm
+        rnorm = wnorm
+        mul!(h, Vprev', v)
+        gemv!('N', -one(T), Vprev, h, one(T), v)
+        wnorm = norm(v)
+    end
+
+    if wnorm ≤ η * rnorm
+        # If we have to reorthogonalize thrice, then we're just numerically in the span
+        return false
+    else
+        # Otherwise we just normalize this new basis vector
+        v ./= wnorm
+        return true
+    end
 end
 
 """
-Perform Arnoldi iterations.
+    orthogonalize!(arnoldi, j) -> Bool
+
+Orthogonalize arnoldi.V[:, j+1] against arnoldi.V[:, 1:j].
+
+Returns true if the column is a valid new basis vector.
+Returns false if the column is numerically in the span of the previous vectors.
+"""
+function orthogonalize!(arnoldi::Arnoldi{T}, j::Integer) where {T}
+    V = arnoldi.V
+    H = arnoldi.H
+
+    # Constant used by ARPACK.
+    η = √2 / 2
+
+    Vprev = view(V, :, 1:j)
+    v = view(V, :, j+1)
+    h = view(H, 1:j, j)
+
+    # Norm before orthogonalization
+    rnorm = norm(v)
+
+    # Orthogonalize: h = Vprev' * v, v ← v - Vprev * Vprev' * v = v - Vprev * h
+    mul!(h, Vprev', v)
+    gemv!('N', -one(T), Vprev, h, one(T), v)
+
+    # Norm after orthogonalization
+    wnorm = norm(v)
+
+    # Reorthogonalize once
+    if wnorm < η * rnorm
+        rnorm = wnorm
+        correction = Vprev' * v
+        gemv!('N', -one(T), Vprev, correction, one(T), v)
+        h .+= correction
+        wnorm = norm(v)
+    end
+
+    if wnorm ≤ η * rnorm
+        # If we have to reorthogonalize thrice, then we're just numerically in the span
+        H[j+1,j] = zero(T)
+        return false
+    else
+        # Otherwise we just normalize this new basis vector
+        H[j+1,j] = wnorm
+        v ./= wnorm
+        return true
+    end
+end
+
+"""
+    iterate_arnoldi!(A, arnoldi, from:to) -> arnoldi
+
+Perform Arnoldi from `from` to `to`.
 """
 function iterate_arnoldi!(A, arnoldi::Arnoldi{T}, range::UnitRange{Int}) where {T}
     V, H = arnoldi.V, arnoldi.H
     
-    @inbounds @views for j = range
-        v = V[:, j + 1]
-        mul!(v, A, V[:, j])
+    for j = range
+        # Generate a new column of the Krylov subspace
+        mul!(view(V, :, j+1), A, view(V, :,j))
 
-        # Orthogonalize
-        mul!(H[1:j,j], V[:,1:j]', v)
-        LinearAlgebra.BLAS.gemv!('N', -one(T), V[:,1:j], H[1:j,j], one(T), v)
-        
-        # This allocates, but yeah.
-        Δh = V[:,1:j]' * v
-        LinearAlgebra.BLAS.gemv!('N', -one(T), V[:,1:j], Δh, one(T), v)
-        H[1:j,j] .+= Δh
-
-        # Normalize
-        H[j + 1, j] = norm(v)
-        v ./= H[j + 1, j]
+        # Orthogonalize it against the other columns
+        # If V[:,j+1] is in the span of V[:,1:j], then we generate a new
+        # vector. If j == n, then obviously we cannot find a new orthogonal
+        # column V[:,j+1].
+        if orthogonalize!(arnoldi, j) === false && j != size(V, 1)
+            reinitialize!(arnoldi, j)
+        end
     end
 
     return arnoldi

--- a/src/run.jl
+++ b/src/run.jl
@@ -7,7 +7,13 @@ function partial_schur(A; min = 5, max = 30, nev = min, tol = eps(real(eltype(A)
     n = size(A, 1)
     prods = min 
 
-    arnoldi = initialize(T, n, max)
+    # Pre-allocated arnoldi decomp
+    arnoldi = Arnoldi{T}(n, max)
+
+    # Start with a random vector
+    reinitialize!(arnoldi)
+
+    # Expand
     iterate_arnoldi!(A, arnoldi, 1 : min)
 
     # min′ is the effective starting point -- may be min - 1 when the last two removed guys

--- a/test/expansion.jl
+++ b/test/expansion.jl
@@ -1,10 +1,11 @@
 # Tests the Arnoldi relation AV = VH when expanding the search subspace
 
 using Test, LinearAlgebra, SparseArrays
-using IRAM: initialize, iterate_arnoldi!
+using IRAM: reinitialize!, Arnoldi, iterate_arnoldi!
 
 @testset "Initialization" begin
-    arnoldi = initialize(Float64, 5, 3)
+    arnoldi = Arnoldi{Float64}(5, 3)
+    reinitialize!(arnoldi)
     @test norm(arnoldi.V[:, 1]) ≈ 1
 end
 
@@ -13,7 +14,8 @@ end
     max = 6
     A = sprand(n, n, .1) + I
 
-    arnoldi = initialize(Float64, n, max)
+    arnoldi = Arnoldi{Float64}(n, max)
+    reinitialize!(arnoldi)
     V, H = arnoldi.V, arnoldi.H
 
     # Do a few iterations

--- a/test/expansion.jl
+++ b/test/expansion.jl
@@ -28,3 +28,22 @@ end
     @test A * V[:,1:max] ≈ V * H
     @test norm(V' * V - I) < 1e-10
 end
+
+@testset "Invariant subspace" begin
+    # Generate a block-diagonal matrix A
+    A = [rand(4,4)  zeros(4,4); 
+         zeros(4,4) rand(4,4)]
+
+    # and an initial vector [1; 0; ... 0]
+    vh = Arnoldi{Float64}(8, 5)
+    V, H = vh.V, vh.H
+    V[:,1] .= 0.0
+    V[1,1] = 1.0
+
+    # Then {v, Av, A²v, A³v}
+    # is an invariant subspace
+    iterate_arnoldi!(A, vh, 1:5)
+
+    @test norm(V' * V - I) < 1e-10
+    @test iszero(H[5, 4])
+end

--- a/test/implicit_restart.jl
+++ b/test/implicit_restart.jl
@@ -1,5 +1,5 @@
 using Test, LinearAlgebra, SparseArrays
-using IRAM: implicit_restart!, initialize, iterate_arnoldi!
+using IRAM: Arnoldi, implicit_restart!, reinitialize!, iterate_arnoldi!
 
 @testset "Implicit restart" begin
 
@@ -9,7 +9,8 @@ using IRAM: implicit_restart!, initialize, iterate_arnoldi!
         A = sprand(T, n, n, 5 / n) + I
         min, max = 5, 8
 
-        arnoldi = initialize(T, n, max)
+        arnoldi = Arnoldi{T}(n, max)
+        reinitialize!(arnoldi)
         V, H = arnoldi.V, arnoldi.H
         iterate_arnoldi!(A, arnoldi, 1 : max)
         λs = sort!(eigvals(view(H, 1:max, 1:max)), by = abs, rev = true)


### PR DESCRIPTION
Based on L. Reichel and W. B. Grag [1].

Basic idea:

1. Orthogonalize v_{j+1} against the previous vecs
2. If v_{j+1} has a small norm, then rescaling it might introduce rounding errors. Reorthogonalize the rounding error away in that case.
3. If a third reorthogonalization is necessary, then we just assume this means v_{j+1} is in the span of v_1 to v_k. In that case set H[j+1,j] = 0 to indicate an invariant subspace and generate a new random v_{j+1} orthogonal against v_1 to v_k (and don't touch H[:, j] ofc.).

This needs tests. Simple test case would be:

```
A = [rand(4,4)  zeros(4,4); 
     zeros(4,4) rand(4,4)]

vh = Arnoldi{Float64}(8, 5)

vh.V[:,1] .= 0.0
vh.V[1,1] = 1.0

iterate_arnoldi!(A, vh, 1:5)
```

Then `V[5:8,1:4] == 0` and `A * V[:, 1:4] == V[:, 1:4] * H[1:4,1:4]` forms an invariant subspace for A. Then `V[:, 5]` has to be a random new vector.

[1] ALGORITHM 686, FORTRAN Subroutines for Updating the QR Decomposition